### PR TITLE
Remove roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,6 @@ dotnet skywalking config sample_app 192.168.0.1:11800
 # Contributing
 This section is in progress here: [Contributing to skywalking-netcore](/CONTIBUTING.md)
 
-# Roadmap
-- Expect to release 0.2 compatible in May. 2018
-- Expect to release 0.3 compatible in June. 2018
-
 # Contact Us
 * Submit an issue
 * [Gitter](https://gitter.im/openskywalking/Lobby) English


### PR DESCRIPTION
I am removing the old ROADMAP before you do the new release. Also, I suggest we should consider providing new ones, including

- When to release the v1.0
- What features should be provided in v1.0
- Other metrics request new 6.0 backend to support, which plans to release at the end of this month.
- Whether do we have plans about moving into Apache, as a new subproject? Maybe, if so, I also suggest that we can give `skywalking-netcore` a new name, if we want.

FYI @OpenSkywalking/pmc 