### PR TITLE
Add a skywalking 6 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A quick list of SkyWalking .NET Core Agent's capabilities
 
 #### Requirements
 - SkyWalking Collector 5.0.0-beta or higher. See SkyWalking backend deploy [docs](https://github.com/apache/incubator-skywalking/blob/5.x/docs/en/Deploy-backend-in-standalone-mode.md).
+- SkyWalking 6 backend is compatible too. The deployment doc is [here](https://github.com/apache/incubator-skywalking/blob/master/docs/en/setup/backend/backend-ui-setup.md). If you are new user, recommand you to read the 
+[whole official documents](https://github.com/apache/incubator-skywalking/blob/master/docs/README.md)
 
 ## Install SkyWalking .NET Core Agent
 


### PR DESCRIPTION
Consider skywalking 6 is also compatible with the current .net core agent, even we hope the .net agent could upgrade to new protocols and concepts, I add the new document links first, in order to make user known that, SkyWalking 6 is ready for the current .net agent.