### PR TITLE
Fix Asp.Net Core package version conflicts

### DIFF
--- a/sample/SkyWalking.Sample.Backend/SkyWalking.Sample.Backend.csproj
+++ b/sample/SkyWalking.Sample.Backend/SkyWalking.Sample.Backend.csproj
@@ -11,6 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite">
+      <Version>2.1.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Update="appsettings.json">

--- a/src/SkyWalking.Abstractions/Config/InstrumentationConfig.cs
+++ b/src/SkyWalking.Abstractions/Config/InstrumentationConfig.cs
@@ -16,6 +16,8 @@
  *
  */
 
+using System;
+
 namespace SkyWalking.Config
 {
     [Config("SkyWalking")]
@@ -23,6 +25,7 @@ namespace SkyWalking.Config
     {
         public string Namespace { get; set; }
 
+        [Obsolete("Use ServiceName.")]
         public string ApplicationCode { get; set; }
         
         public string ServiceName { get; set; }

--- a/src/SkyWalking.Agent.AspNetCore/SkyWalking.Agent.AspNetCore.csproj
+++ b/src/SkyWalking.Agent.AspNetCore/SkyWalking.Agent.AspNetCore.csproj
@@ -11,8 +11,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\SkyWalking.Abstractions\SkyWalking.Abstractions.csproj" />

--- a/src/SkyWalking.Diagnostics.AspNetCore/HostingDiagnosticProcessor.cs
+++ b/src/SkyWalking.Diagnostics.AspNetCore/HostingDiagnosticProcessor.cs
@@ -36,7 +36,8 @@ namespace SkyWalking.AspNetCore.Diagnostics
         private readonly InstrumentationConfig _config;
         private readonly IContextCarrierFactory _contextCarrierFactory;
 
-        public HostingTracingDiagnosticProcessor(IConfigAccessor configAccessor,IContextCarrierFactory contextCarrierFactory)
+        public HostingTracingDiagnosticProcessor(IConfigAccessor configAccessor,
+            IContextCarrierFactory contextCarrierFactory)
         {
             _config = configAccessor.Get<InstrumentationConfig>();
             _contextCarrierFactory = contextCarrierFactory;
@@ -48,7 +49,7 @@ namespace SkyWalking.AspNetCore.Diagnostics
             var carrier = _contextCarrierFactory.Create();
             foreach (var item in carrier.Items)
                 item.HeadValue = httpContext.Request.Headers[item.HeadKey];
-            var httpRequestSpan = ContextManager.CreateEntrySpan($"{_config.ApplicationCode} {httpContext.Request.Path}", carrier);
+            var httpRequestSpan = ContextManager.CreateEntrySpan(httpContext.Request.Path, carrier);
             httpRequestSpan.AsHttp();
             httpRequestSpan.SetComponent(ComponentsDefine.AspNetCore);
             Tags.Url.Set(httpRequestSpan, httpContext.Request.Path);
@@ -57,7 +58,10 @@ namespace SkyWalking.AspNetCore.Diagnostics
                 new Dictionary<string, object>
                 {
                     {"event", "AspNetCore Hosting BeginRequest"},
-                    {"message", $"Request starting {httpContext.Request.Protocol} {httpContext.Request.Method} {httpContext.Request.GetDisplayUrl()}"}
+                    {
+                        "message",
+                        $"Request starting {httpContext.Request.Protocol} {httpContext.Request.Method} {httpContext.Request.GetDisplayUrl()}"
+                    }
                 });
             httpContext.Items[HttpContextDiagnosticStrings.SpanKey] = httpRequestSpan;
         }
@@ -82,25 +86,28 @@ namespace SkyWalking.AspNetCore.Diagnostics
                 new Dictionary<string, object>
                 {
                     {"event", "AspNetCore Hosting EndRequest"},
-                    {"message", $"Request finished {httpContext.Response.StatusCode} {httpContext.Response.ContentType}"}
+                    {
+                        "message",
+                        $"Request finished {httpContext.Response.StatusCode} {httpContext.Response.ContentType}"
+                    }
                 });
             ContextManager.StopSpan(httpRequestSpan);
         }
 
         [DiagnosticName("Microsoft.AspNetCore.Diagnostics.UnhandledException")]
-        public void DiagnosticUnhandledException([Property]HttpContext httpContext, [Property]Exception exception)
+        public void DiagnosticUnhandledException([Property] HttpContext httpContext, [Property] Exception exception)
         {
             ContextManager.ActiveSpan?.ErrorOccurred()?.Log(exception);
         }
 
         [DiagnosticName("Microsoft.AspNetCore.Hosting.UnhandledException")]
-        public void HostingUnhandledException([Property]HttpContext httpContext, [Property]Exception exception)
+        public void HostingUnhandledException([Property] HttpContext httpContext, [Property] Exception exception)
         {
             ContextManager.ActiveSpan?.ErrorOccurred()?.Log(exception);
         }
-        
+
         //[DiagnosticName("Microsoft.AspNetCore.Mvc.BeforeAction")]
-        public void BeforeAction([Property]ActionDescriptor actionDescriptor, [Property]HttpContext httpContext)
+        public void BeforeAction([Property] ActionDescriptor actionDescriptor, [Property] HttpContext httpContext)
         {
             var span = httpContext.Items[HttpContextDiagnosticStrings.SpanKey] as ISpan;
             if (span == null)
@@ -108,12 +115,13 @@ namespace SkyWalking.AspNetCore.Diagnostics
                 return;
             }
 
-            var events = new Dictionary<string, object> {{"event", "AspNetCore.Mvc Executing action method"}, {"Action method", actionDescriptor.DisplayName}};
+            var events = new Dictionary<string, object>
+                {{"event", "AspNetCore.Mvc Executing action method"}, {"Action method", actionDescriptor.DisplayName}};
             span.Log(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), events);
         }
 
         //[DiagnosticName("Microsoft.AspNetCore.Mvc.AfterAction")]
-        public void AfterAction([Property]ActionDescriptor actionDescriptor, [Property]HttpContext httpContext)
+        public void AfterAction([Property] ActionDescriptor actionDescriptor, [Property] HttpContext httpContext)
         {
             var span = httpContext.Items[HttpContextDiagnosticStrings.SpanKey] as ISpan;
             if (span == null)

--- a/src/SkyWalking.Diagnostics.AspNetCore/SkyWalking.Diagnostics.AspNetCore.csproj
+++ b/src/SkyWalking.Diagnostics.AspNetCore/SkyWalking.Diagnostics.AspNetCore.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/src/SkyWalking.Diagnostics.CAP/SkyWalking.Diagnostics.CAP.csproj
+++ b/src/SkyWalking.Diagnostics.CAP/SkyWalking.Diagnostics.CAP.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetCore.CAP" Version="2.3.1" />
+    <PackageReference Include="DotNetCore.CAP" Version="2.3.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore.Npgsql/NpgsqlEFCoreSpanMetadataProvider.cs
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore.Npgsql/NpgsqlEFCoreSpanMetadataProvider.cs
@@ -25,10 +25,10 @@ namespace SkyWalking.Diagnostics.EntityFrameworkCore
     public class NpgsqlEFCoreSpanMetadataProvider : IEfCoreSpanMetadataProvider
     {
         public IComponent Component { get; } = ComponentsDefine.Npgsql_EntityFrameworkCore_PostgreSQL;
-        
+
         public bool Match(DbConnection connection)
         {
-           return connection is NpgsqlConnection;
+            return connection.GetType().FullName == "Npgsql.NpgsqlConnection";
         }
 
         public string GetPeer(DbConnection connection)

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore.Npgsql/SkyWalking.Diagnostics.EntityFrameworkCore.Npgsql.csproj
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore.Npgsql/SkyWalking.Diagnostics.EntityFrameworkCore.Npgsql.csproj
@@ -18,6 +18,6 @@
     <ProjectReference Include="..\SkyWalking.Utilities.DependencyInjection\SkyWalking.Utilities.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore.Pomelo.MySql/MySqlEFCoreSpanMetadataProvider.cs
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore.Pomelo.MySql/MySqlEFCoreSpanMetadataProvider.cs
@@ -28,7 +28,7 @@ namespace SkyWalking.Diagnostics.EntityFrameworkCore
         
         public bool Match(DbConnection connection)
         {
-            return connection is MySqlConnection;
+            return connection.GetType().FullName == "MySql.Data.MySqlClient.MySqlConnection";
         }
 
         public string GetPeer(DbConnection connection)

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore.Pomelo.MySql/SkyWalking.Diagnostics.EntityFrameworkCore.Pomelo.MySql.csproj
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore.Pomelo.MySql/SkyWalking.Diagnostics.EntityFrameworkCore.Pomelo.MySql.csproj
@@ -18,6 +18,6 @@
     <ProjectReference Include="..\SkyWalking.Utilities.DependencyInjection\SkyWalking.Utilities.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.1.4" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.1.4" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore.Sqlite/SkyWalking.Diagnostics.EntityFrameworkCore.Sqlite.csproj
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore.Sqlite/SkyWalking.Diagnostics.EntityFrameworkCore.Sqlite.csproj
@@ -18,6 +18,6 @@
     <ProjectReference Include="..\SkyWalking.Utilities.DependencyInjection\SkyWalking.Utilities.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore.Sqlite/SqliteEFCoreSpanMetadataProvider.cs
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore.Sqlite/SqliteEFCoreSpanMetadataProvider.cs
@@ -25,10 +25,10 @@ namespace SkyWalking.Diagnostics.EntityFrameworkCore
     public class SqliteEFCoreSpanMetadataProvider : IEfCoreSpanMetadataProvider
     {
         public IComponent Component { get; } = ComponentsDefine.EntityFrameworkCore_Sqlite;
-        
+
         public bool Match(DbConnection connection)
         {
-            return connection is SqliteConnection;
+            return connection.GetType().FullName == "Microsoft.Data.Sqlite.SqliteConnection";
         }
 
         public string GetPeer(DbConnection connection)
@@ -36,12 +36,12 @@ namespace SkyWalking.Diagnostics.EntityFrameworkCore
             string dataSource;
             switch (connection.DataSource)
             {
-                    case "":
-                        dataSource = "sqlite:memory:db";
-                        break;
-                    default:
-                        dataSource = connection.DataSource;
-                        break;
+                case "":
+                    dataSource = "sqlite:memory:db";
+                    break;
+                default:
+                    dataSource = connection.DataSource;
+                    break;
             }
 
             return $"{dataSource}";

--- a/src/SkyWalking.Diagnostics.EntityFrameworkCore/SkyWalking.Diagnostics.EntityFrameworkCore.csproj
+++ b/src/SkyWalking.Diagnostics.EntityFrameworkCore/SkyWalking.Diagnostics.EntityFrameworkCore.csproj
@@ -12,8 +12,8 @@
     <RootNamespace>SkyWalking.Diagnostics.EntityFrameworkCore</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SkyWalking.Abstractions\SkyWalking.Abstractions.csproj" />

--- a/src/SkyWalking.Diagnostics.MySqlData/SkyWalking.Diagnostics.MySqlData.csproj
+++ b/src/SkyWalking.Diagnostics.MySqlData/SkyWalking.Diagnostics.MySqlData.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="6.10.7" />
+    <PackageReference Include="MySql.Data" Version="6.10.7" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SkyWalking.Diagnostics.SqlClient/SkyWalking.Diagnostics.SqlClient.csproj
+++ b/src/SkyWalking.Diagnostics.SqlClient/SkyWalking.Diagnostics.SqlClient.csproj
@@ -17,6 +17,6 @@
     <ProjectReference Include="..\SkyWalking.Utilities.DependencyInjection\SkyWalking.Utilities.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/SkyWalking.Utilities.Configuration/SkyWalking.Utilities.Configuration.csproj
+++ b/src/SkyWalking.Utilities.Configuration/SkyWalking.Utilities.Configuration.csproj
@@ -17,9 +17,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     </ItemGroup>
 </Project>

--- a/src/SkyWalking.Utilities.DependencyInjection/SkyWalking.Utilities.DependencyInjection.csproj
+++ b/src/SkyWalking.Utilities.DependencyInjection/SkyWalking.Utilities.DependencyInjection.csproj
@@ -15,6 +15,6 @@
     <ProjectReference Include="..\SkyWalking.Core\SkyWalking.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/SkyWalking.Utilities.Logging/DefaultLoggerFactory.cs
+++ b/src/SkyWalking.Utilities.Logging/DefaultLoggerFactory.cs
@@ -29,7 +29,9 @@ namespace SkyWalking.Utilities.Logging
 {
     public class DefaultLoggerFactory : ILoggerFactory
     {
-        private const string outputTemplate = @"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{ApplicationCode}] [{Level}] {SourceContext} : {Message}{NewLine}{Exception}";
+        private const string outputTemplate =
+            @"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{ApplicationCode}] [{Level}] {SourceContext} : {Message}{NewLine}{Exception}";
+
         private readonly MSLoggerFactory _loggerFactory;
         private readonly LoggingConfig _loggingConfig;
 
@@ -41,13 +43,12 @@ namespace SkyWalking.Utilities.Logging
 
             var level = EventLevel(_loggingConfig.Level);
 
-            _loggerFactory.AddSerilog(new LoggerConfiguration().
-                MinimumLevel.Verbose().
-                Enrich.WithProperty("SourceContext", null).
-                Enrich.WithProperty(nameof(instrumentationConfig.ApplicationCode), instrumentationConfig.ApplicationCode).
-                Enrich.FromLogContext().
-                WriteTo.RollingFile(_loggingConfig.FilePath, level, outputTemplate, null, 1073741824, 31, null, false, false, TimeSpan.FromMilliseconds(500)).
-                CreateLogger());
+            _loggerFactory.AddSerilog(new LoggerConfiguration().MinimumLevel.Verbose().Enrich
+                .WithProperty("SourceContext", null).Enrich
+                .WithProperty(nameof(instrumentationConfig.ServiceName),
+                    instrumentationConfig.ServiceName ?? instrumentationConfig.ApplicationCode).Enrich
+                .FromLogContext().WriteTo.RollingFile(_loggingConfig.FilePath, level, outputTemplate, null, 1073741824,
+                    31, null, false, false, TimeSpan.FromMilliseconds(500)).CreateLogger());
         }
 
         public ILogger CreateLogger(Type type)
@@ -57,7 +58,9 @@ namespace SkyWalking.Utilities.Logging
 
         private static LogEventLevel EventLevel(string level)
         {
-            return LogEventLevel.TryParse<LogEventLevel>(level, out var logEventLevel) ? logEventLevel : LogEventLevel.Error;
+            return LogEventLevel.TryParse<LogEventLevel>(level, out var logEventLevel)
+                ? logEventLevel
+                : LogEventLevel.Error;
         }
     }
 }

--- a/src/SkyWalking.Utilities.Logging/SkyWalking.Utilities.Logging.csproj
+++ b/src/SkyWalking.Utilities.Logging/SkyWalking.Utilities.Logging.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
         <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     </ItemGroup>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

### Bug fix
- Bug description.

The Agent depend on a higher version of the Asp.NetCore framework package (such as V2.2), while some users still use the lower version of the Asp.NetCore framework (such as V2.0).

- How to fix?

Use [PrivateAssets](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets) to hide dependencies visible to the user and downgrade some dependencies. 
