### PR TITLE
Remove the Apache SkyWalking logo first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 SkyWalking C#/.NET instrument agent
 ==========
 
-<img src="https://skywalkingtest.github.io/page-resources/3.0/skywalking.png" alt="Sky Walking logo" height="90px" align="right" />
-
 [Apache SkyWalking](https://github.com/apache/incubator-skywalking) is an APM designed for microservices, cloud native and container-based (Docker, K8s, Mesos) architectures. **SkyWalking-netcore** provides the native support agent in C# and .NETStandard platform, with the helps from Apache SkyWalking committer team.
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/asfskywalking.svg?style=for-the-badge&label=Follow&logo=twitter)](https://twitter.com/AsfSkyWalking)


### PR DESCRIPTION
@liuhaoyang Since you have not decided the solution, I just try to remove the SkyWalking logo first.
I hope we could deal with the trademark and branding issue as soon as possible.